### PR TITLE
docs: add Phase 0 governance and sprint planning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What changed
+-
+
+## Why
+-
+
+## Architecture / ADR impact
+- [ ] Boundary ownership preserved
+- [ ] Virtual Development Mode assumptions still accurate
+- [ ] Docs updated if implemented behavior changed
+
+## How to test
+- [ ] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
+- [ ] `cmake --build build`
+- [ ] `ctest --test-dir build --output-on-failure`
+- [ ] Manual check:
+
+## Reviewer notes
+- Phase touched:
+- Key tradeoffs:
+- Known follow-up work:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,186 @@
+# Contributing To VTCN
+
+VTCN follows disciplined change control so the repo stays readable, maintainable,
+and technically honest. The repo should reflect what is implemented now, what is
+host-side only, and what is planned for later phases.
+
+AI tools may assist with implementation, but changes still need human review,
+tests, and architecture discipline.
+
+## Commit Message Guidelines
+
+Each commit message consists of:
+- header, required
+- body, strongly encouraged
+- footer, optional
+
+No line may exceed 100 characters.
+
+### Format
+
+`type(scope): subject`
+
+The header is mandatory. The scope is required for this project.
+
+### Revert
+
+If reverting a commit:
+
+`revert(scope): subject`
+
+The body should include:
+
+`This reverts commit <sha>.`
+
+### Types
+
+Use one of:
+- `feat`: a new feature
+- `fix`: a bug fix
+- `refactor`: code change without feature or bug fix
+- `perf`: performance improvement
+- `test`: add or update tests
+- `docs`: documentation-only changes
+- `style`: formatting only
+- `chore`: tooling, build, or dependency changes
+- `ci`: CI workflow changes
+
+### Scopes
+
+Approved scopes for VTCN:
+- `daemon`
+- `signal`
+- `rpm`
+- `protocol`
+- `crc`
+- `hal`
+- `mcu`
+- `schema`
+- `toolchain`
+- `build`
+- `test`
+- `docs`
+- `repo`
+- `ci`
+- `systemd`
+- `phase0`
+
+Use lowercase.
+
+### Examples
+
+- `feat(signal): add 36-1 pulse generation`
+- `feat(rpm): estimate rpm from tooth intervals`
+- `test(phase0): add end-to-end runtime coverage`
+- `chore(toolchain): migrate project to c++23`
+- `ci(build): add cmake build-and-test workflow`
+
+### Subject Rules
+
+The subject must:
+- use imperative present tense
+- not capitalize the first letter
+- not end with a period
+- be concise and descriptive
+
+Correct:
+- `add monotonic pulse generation`
+- `enforce c++23 across daemon targets`
+- `archive speculative docs for later phases`
+
+Incorrect:
+- `Added pulse generation.`
+- `Fixes stuff.`
+
+### Body
+
+Use the body to explain:
+- what changed
+- why it changed
+- how it differs from previous behavior
+
+Keep lines under 100 characters.
+
+Example:
+
+Add a host-side 36-1 pulse source for Phase 0 validation.
+Previously the repo documented the signal path but did not provide
+an implemented, testable source of deterministic pulse events.
+This adds timestamped pulses with optional light jitter for daemon-side processing.
+
+Closes #12
+
+### Footer
+
+Use the footer for:
+- issue references, for example `Closes #12`
+- breaking changes, beginning with `BREAKING CHANGE:`
+
+## Branching Strategy
+
+- Prefer one branch per issue when practical
+- Branch name format:
+  - `issue/<number>-short-description`
+
+Examples:
+- `issue/7-cpp23-migration`
+- `issue/9-signal-generator`
+- `issue/12-ci-build-test`
+
+Rules:
+- merge via pull request
+- keep PRs scoped and reviewable
+- do not push directly to `main`
+- before external submission, either merge the sendable state to `main` or send a branch
+  link with clear review guidance
+
+## Code Style
+
+### Language And Standard
+- C++23 for active daemon targets
+- prefer the standard library over ad hoc utilities where practical
+- use modern features when they improve correctness, readability, or maintainability
+
+### Design Guidance
+- prefer clear value types and small classes
+- keep module responsibilities narrow
+- use pure functions where possible for core signal and RPM logic
+- avoid unnecessary inheritance or abstraction in Phase 0
+- separate internal runtime types from wire or protocol formats
+
+### Naming
+- files: project-consistent, prefer one convention and keep it consistent
+- types and classes: `PascalCase`
+- functions and variables: project-consistent lower style
+- constants: `kCamelCase` or `UPPER_SNAKE_CASE` if standardized
+
+### Error Handling
+- be explicit and predictable
+- avoid silent failure
+- prefer structured status or result returns where appropriate
+- do not use exceptions for ordinary control flow unless the project adopts that model
+
+### Logging And Output
+- output should help a reviewer understand runtime behavior
+- keep logs concise and deterministic
+- do not overclaim what the runtime proves
+
+### Architecture Honesty
+- do not label host-side simulation as hardware validation
+- do not blur HAL responsibilities with daemon policy or processing
+- keep future-facing docs clearly separated from implemented behavior
+
+## Security And Safety Basics
+
+- no secrets in git
+- no fabricated validation claims
+- external interfaces and payload formats must be documented if added
+- changes to protocol framing should update docs and associated design notes
+
+## Repo Discipline
+
+Before opening a PR, ask:
+- does this reflect what the repo can actually do now?
+- can I explain this confidently in an interview?
+- did I add tests for the logic I changed?
+- did I keep the scope narrow enough to review quickly?

--- a/README.md
+++ b/README.md
@@ -1,476 +1,138 @@
-# VTCN – Vehicle Telemetry & Control Node
+# VTCN
 
-Embedded Linux telemetry platform built on the **BeagleBone Black (ARM Cortex‑A8)**.
+Vehicle Telemetry and Control Node is a systems-oriented C++ project aimed at a disciplined telemetry node
+architecture centered on the BeagleBone Black, with clear separation between hardware access, daemon-side
+processing, and versioned telemetry interfaces.
 
-This project is intentionally structured as a **production‑style embedded systems engineering exercise**. All features must be implemented and validated on real hardware. No simulated claims.
+## Current State
 
-VTCN is also designed to integrate with the **Edge AI Diagnostics Platform**, which consumes telemetry streams for analysis, diagnostics, and automation workflows.
+The repository is currently in Phase 0 Virtual Development Mode.
 
----
+That means the active, reviewable slice is host-side only:
+- CMake-based daemon scaffolding
+- host-buildable C++ code and tests
+- architecture and ADR documentation
+- a weekend Phase 0 effort focused on crank pulse simulation, gap detection, and RPM estimation
 
-# Project Purpose
+That does not mean:
+- BeagleBone hardware validation is complete
+- HAL implementations are validated on target
+- MCU timing behavior is proven
+- transport, logging, or storage are production-ready
 
-VTCN exists to demonstrate real-world embedded Linux competencies while providing a telemetry node suitable for robotics, automotive, and aerospace-style systems.
+## Project Direction
 
-Core competencies demonstrated:
+The long-term project goal is to build a telemetry node that can:
+- acquire signals from real hardware interfaces
+- normalize and process those signals in a daemon layer
+- publish versioned telemetry records to downstream consumers
+- preserve evidence and validation discipline as the system matures
 
-- ARM-based Linux bring-up
-- Cross-compilation workflows (x86 → ARM)
-- Hardware interface validation (GPIO, I2C, SPI, UART, ADC)
-- Telemetry protocol design
-- Structured logging (SQLite)
-- TCP telemetry streaming
-- Low-level debugging (gdb, strace, perf, dmesg)
-- Linux kernel module development
-- systemd service hardening
-- Reproducible builds and validation procedures
+The intended architecture is:
 
-The platform is also intended to support **real vehicle telemetry work**, beginning with the OM606 engine swap project (TPS and coolant telemetry).
-
----
-
-# Relationship to the Edge AI Diagnostics Platform
-
-VTCN acts as a **telemetry acquisition and transport node** for the Edge AI Diagnostics Platform.
-
-Architecture relationship:
-
-```
-Physical Sensors
-      │
-      ▼
-HAL (BBB / MCU)
-      │
-      ▼
-VTCN Telemetry Daemon
-      │
-      ├── SQLite Local Logging
-      │
-      └── TCP Telemetry Stream
-              │
-              ▼
-Edge AI Diagnostics Platform
-              │
-              ▼
-Diagnostics / Analysis / Automation
+```text
+Physical Signals
+    |
+    v
+HAL or MCU-facing transport
+    |
+    v
+VTCN daemon
+    |-- processing and estimation
+    |-- framing
+    |-- future logging, storage, and networking
+    |
+    v
+Documented downstream consumers
 ```
 
-The **Edge AI Diagnostics Platform** is responsible for:
+## Architecture Principles
 
-- signal analysis
-- anomaly detection
-- system diagnostics
-- telemetry visualization
+These principles are active now, not future decoration:
+- HAL owns hardware I/O only
+- daemon-side logic owns normalization, policy, processing, estimation, and framing
+- protocol framing is separate from internal runtime structures
+- internal C++ object layout is not a wire contract
+- host-side validation is useful, but it is not hardware evidence
 
-The **contract between VTCN and the Edge AI Diagnostics Platform** is defined in:
+See:
+- `docs/adr/ADR-001-hal-separation.md`
+- `docs/adr/ADR-002-telemetry-framing.md`
+- `docs/architecture/component_boundaries.md`
+- `docs/procedures/virtual_development_mode.md`
 
-```
-docs/interfaces/edge_ai_diagnostics_contract.md
-```
+## Phase 0 Focus
 
-This contract defines:
+The current near-term implementation target is a host-side prototype inside `vtcn-daemon` that demonstrates:
+- 36-1 crankshaft pulse generation with monotonic timestamps
+- missing-tooth gap detection
+- RPM estimation from pulse intervals
+- clear CLI output and optionally simple telemetry framing
+- deterministic unit and integration tests
 
-- telemetry frame format
-- message versioning
-- CRC integrity checks
-- transport expectations
-- compatibility guarantees
+This is intentionally a narrow slice. It is large enough to discuss systems thinking, signal processing,
+boundary ownership, testing, and build discipline without pretending to be hardware validation.
 
-VTCN must follow this contract strictly to ensure interoperability.
+## Repository Layout
 
----
+```text
+docs/
+  adr/
+  architecture/
+  interfaces/
+  procedures/
 
-# Development Principles
+vtcn-daemon/
+  include/
+  src/
+  tests/
 
-## Hardware‑First Validation
-
-Every subsystem must be tested and documented on the **BeagleBone Black hardware**.
-
-## Reproducibility
-
-All builds, deployments, and validation procedures must be reproducible from a clean environment.
-
-## Modular Architecture
-
-System responsibilities are intentionally separated:
-
-| Component | Responsibility |
-|--------|--------|
-| HAL | hardware I/O only |
-| Telemetry Daemon | filtering, calibration, framing, networking |
-| Protocol | versioned message format |
-| MCU Coprocessor | deterministic signal capture |
-
-## Evidence‑Driven Engineering
-
-Each phase requires:
-
-- logs
-- validation output
-- documented procedures
-
-Evidence is stored under:
-
-```
-docs/test-results/
+toolchain/
+mcu-node/
+lkm/
+systemd/
 ```
 
----
+Interpretation:
+- `docs/` holds the architecture truth layer
+- `vtcn-daemon/` is the active host-side implementation area
+- `toolchain/`, `mcu-node/`, `lkm/`, and `systemd/` remain future-facing until backed by code and evidence
 
-# Repository Structure
+## Build And Test
 
-```
-vtcn/
+Current host-side commands:
 
-  README.md
-  CMakeLists.txt
-
-  docs/
-    architecture/
-      system_overview.md
-      component_boundaries.md
-      data_flow.md
-      failure_modes.md
-
-    interfaces/
-      hal_adc.md
-      hal_gpio.md
-      hal_i2c.md
-      hal_spi.md
-      hal_uart.md
-      mcu_protocol.md
-      telemetry_protocol.md
-      edge_ai_diagnostics_contract.md
-
-    procedures/
-      beaglebone_bringup.md
-      cross_compile_setup.md
-      virtual_development_mode.md
-      adc_validation.md
-      debugging_workflow.md
-
-    adr/
-      ADR-001-hal-separation.md
-      ADR-002-telemetry-framing.md
-      ADR-003-mcu-coprocessor.md
-
-    ai/
-      ai_context.md
-      ai_rules.md
-      project_summary.md
-
-    test-results/
-
-  toolchain/
-    beaglebone-gcc.cmake
-    build.sh
-    deploy.sh
-
-  vtcn-daemon/
-    CMakeLists.txt
-
-    include/
-      vtcn/
-        hal/
-        telemetry/
-        logging/
-        storage/
-        net/
-        config/
-
-    src/
-
-    tests/
-      unit/
-      integration/
-      fixtures/
-
-  mcu-node/
-    firmware/
-    protocol/
-    test-tools/
-
-  proto/
-
-  schema/
-
-  systemd/
-
-  lkm/
-```
-
----
-
-# Testing Strategy
-
-Testing in VTCN is divided into three categories.
-
-## Unit Tests
-
-Framework:
-
-```
-GoogleTest
-```
-
-Purpose:
-
-- validate pure logic
-- config parsing
-- frame encoding/decoding
-- CRC calculation
-
-Location:
-
-```
-vtcn-daemon/tests/unit/
-```
-
-## Integration Tests
-
-Purpose:
-
-- verify module interaction
-- daemon startup validation
-- protocol round-trip checks
-
-Location:
-
-```
-vtcn-daemon/tests/integration/
-```
-
-## Hardware Validation
-
-Hardware interfaces cannot be fully tested on host systems.
-
-Instead:
-
-- validation tools are created
-- procedures are documented
-- evidence is recorded
-
-Documentation:
-
-```
-docs/procedures/
-```
-
-Evidence:
-
-```
-docs/test-results/
-```
-
-## Host-Side Baseline
-
-During Phase 0 Virtual Development Mode, the host-only scaffold can be checked with:
-
-```
-cmake -S . -B build
+```text
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-These commands validate build wiring and host-side test scaffolding only. They do not constitute hardware validation on the BeagleBone Black.
+These commands validate host-side build wiring and tests only.
 
----
+## What Monday Should Show
 
-# MCU Coprocessor (Arduino / Future STM32)
+For the immediate submission goal, the repo should demonstrate:
+- modern C++ design in a small systems slice
+- deterministic time-based signal handling
+- clear module ownership
+- real tests and clean build tooling
+- documentation that is ambitious but honest
 
-The BeagleBone Black remains the **primary embedded Linux platform**.
+## Roadmap
 
-The MCU node acts as a **real-time coprocessor**.
+Planned later phases may include:
+- BeagleBone bring-up and target validation
+- HAL implementations for BBB interfaces
+- optional MCU-assisted deterministic capture
+- telemetry framing expansion
+- transport, storage, and deployment hardening
 
-### Responsibilities
+Those remain future work until backed by implementation and evidence.
 
-- capture high-frequency pulse inputs
-- deterministic timing via hardware timers
-- analog signal conditioning
-- watchdog functionality
+## Archived Baseline
 
-### Architectural Rule
+The previous top-level README was preserved at:
+- `docs/readme-old.md`
 
-```
-MCU = real-time acquisition
-BBB = system orchestration
-```
-
-The MCU must never replace Linux application logic.
-
----
-
-# Phase Roadmap
-
-## Phase 1 – Platform Foundation
-
-Objective:
-
-Establish a stable ARM Linux development target.
-
-Deliverables:
-
-- Debian image flashed and boot validated
-- SSH secured (key-only authentication)
-- serial console operational
-- documentation of boot process and exposed interfaces
-
-Evidence Required:
-
-```
-uname -a
-
-dmesg
-
-/sys and /dev listings
-```
-
----
-
-## Phase 2 – Toolchain & Cross‑Compilation
-
-Objective:
-
-Build reproducible host → ARM workflow.
-
-Deliverables:
-
-- ARM cross compiler installed
-- CMake toolchain configuration
-- deploy scripts
-- cross‑compiled binary running on BBB
-
----
-
-## Phase 3 – Hardware Interface Layer (HAL)
-
-Interfaces:
-
-- ADC (IIO)
-- GPIO
-- I2C
-- SPI
-- UART
-
-Deliverables:
-
-- HAL modules
-- validation tools
-- calibration documentation
-
----
-
-## Phase 4 – Debugging & Observability
-
-Tools:
-
-- gdb
-- strace
-- perf
-- dmesg
-
----
-
-## Phase 5 – Kernel Module
-
-Deliverables:
-
-- loadable kernel module
-- `/dev/vtcn` device
-- read/write interface
-
----
-
-## Phase 6 – Productionization
-
-Deliverables:
-
-- systemd service
-- watchdog integration
-- structured logging
-
----
-
-## Phase 7 – Yocto Migration
-
-Deliverables:
-
-- Yocto image
-- custom recipe for daemon
-- reproducible build steps
-
----
-
-# Telemetry Architecture
-
-High-Level Flow
-
-```
-Sensors
-   │
-   ▼
-HAL Layer
-   │
-   ▼
-Telemetry Daemon
-   │
- ┌─┴───────────┐
- ▼             ▼
-SQLite        TCP Stream
-                 │
-                 ▼
-       Edge AI Diagnostics Platform
-```
-
-Telemetry frames must include:
-
-- magic number
-- protocol version
-- monotonic timestamp
-- payload length
-- CRC32
-
-Protocol definitions are stored under:
-
-```
-docs/interfaces/
-```
-
----
-
-# Definition of Success
-
-VTCN is considered successful when:
-
-- it runs reliably on ARM hardware
-- it acquires real sensor data
-- hardware interfaces are validated
-- telemetry streams reach the Edge AI Diagnostics Platform
-- services run under systemd
-- procedures allow reproducible deployment
-
----
-
-# Current Status
-
-Phase: **Virtual Development Mode (Phase 0)**
-
-Next Action:
-
-1. Continue host-side scaffolding, interface work, and pure-logic tests
-2. Prepare Phase 1 bring-up and validation procedures
-3. Defer BeagleBone Black hardware claims until target evidence exists
-
----
-
-# Author Intent
-
-This project is designed to serve as a **portfolio‑grade embedded systems platform** demonstrating:
-
-- embedded Linux platform engineering
-- hardware interface development
-- telemetry system architecture
-- debugging and validation workflows
-- professional engineering documentation
-
-The project intentionally mirrors practices used in aerospace, robotics, and advanced automotive embedded systems development.
+It is kept as historical context, not as the current repo truth source.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,79 @@
+# Reviews (VTCN)
+
+## Review Checklist
+
+### Scope And Architecture
+- Does this change stay inside the issue scope?
+- Are module boundaries respected?
+  - host-side pulse source or simulation
+  - daemon processing
+  - protocol framing
+  - docs, build, or CI
+- Does the implementation align with current ADRs and Phase 0 constraints?
+- Does the change avoid making unsupported hardware claims?
+- Is Virtual Development Mode still described honestly?
+
+### Correctness
+- Are timing units explicit and consistent?
+  - prefer monotonic timestamps in integer microseconds or clearly documented equivalents
+- Is 36-1 wheel behavior modeled correctly?
+- Is the missing-tooth gap represented and detected correctly?
+- Is RPM estimation derived from the correct interval set?
+- Are tolerance thresholds documented and justified?
+- Are edge cases handled?
+  - empty pulse list
+  - too few samples
+  - malformed intervals
+  - jitter or noise cases
+
+### Modern C++ And Design Quality
+- Does the code use modern C++23 where it improves clarity or correctness?
+- Are types strong enough to avoid primitive confusion?
+- Is const-correctness respected?
+- Are interfaces small and purposeful?
+- Is logic testable, with pure functions where practical?
+- Is the design simple enough for Phase 0, without speculative abstraction?
+
+### Maintainability
+- Warnings are enabled and the code builds cleanly
+- Error handling is explicit and predictable
+- Naming is clear and consistent
+- Output is useful for debugging but not noisy
+- Comments explain intent, not syntax
+- New code fits the repo structure and current architecture
+
+### Testing And Tooling
+- Unit tests were added or updated for new logic
+- Integration coverage exists for the end-to-end Phase 0 path where appropriate
+- CI passes for build and tests
+- New behavior includes at least one deterministic test
+- Sanitizers or extra checks are used where practical and low risk
+
+### Docs And Evidence Discipline
+- README or current-state docs were updated if behavior changed
+- Design notes reflect what is actually implemented now
+- Future work is clearly separated from current capability
+- Speculative or AI-heavy docs are archived, relabeled, or removed from active paths
+- A reviewer can understand how to build, run, and test the current slice
+
+## When To Request Changes
+
+Request changes if:
+- the PR exceeds the issue scope without a strong reason
+- architecture boundaries are blurred or violated
+- host-side work is written as if it proves hardware integration
+- tests were not added for new logic
+- timing assumptions or thresholds are unexplained
+- protocol or wire format changes happened without corresponding docs
+- CI or build tooling broke or became harder to run
+- the repo now oversells implemented capability
+
+## Good Enough Standard
+
+This is a systems-oriented C++ project. Prioritize:
+- correctness
+- deterministic behavior at boundaries
+- honest evidence
+- clean modular design
+- testability
+- clarity over cleverness

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,82 @@
+# Testing (VTCN)
+
+This project uses CMake, CTest, and GoogleTest for unit and integration testing.
+
+## Goals
+- Unit test all new or changed logic
+- Keep tests deterministic and fast
+- Prefer pure functions or narrowly scoped classes for signal processing logic
+- Validate host-side behavior honestly without implying hardware validation
+
+## Commands
+- Configure:
+  - `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
+- Build:
+  - `cmake --build build`
+- Run tests:
+  - `ctest --test-dir build --output-on-failure`
+- Optional verbose run:
+  - `ctest --test-dir build -V`
+
+If presets are added later, document those commands here.
+
+## What Must Be Unit Tested
+
+Minimum expectations for new logic:
+- Signal generation behavior
+  - correct pulse count for a 36-1 wheel
+  - monotonic timestamp ordering
+  - one oversized gap interval per revolution
+- Gap detection behavior
+  - detects the missing-tooth gap on clean input
+  - remains stable under light jitter
+- RPM estimation behavior
+  - estimated RPM remains within a documented tolerance window
+  - the gap interval is excluded or handled intentionally
+  - malformed or insufficient data is handled safely
+- Protocol framing and CRC behavior if framing is included in the current slice
+- Argument or config parsing for runtime or demo behavior
+
+## Integration Tests
+
+Allowed and encouraged when they remain fast.
+
+Examples:
+- full pipeline: host pulse source -> gap detection -> RPM estimation
+- Phase 0 runtime smoke test
+- optional frame encode or decode round trip if protocol framing is implemented
+
+Avoid:
+- tests that require BeagleBone hardware
+- tests that require MCU hardware
+- tests that require real network services
+- tests that depend on wall-clock timing
+- slow, flaky, or nondeterministic tests
+
+## Test Structure
+
+- Unit tests live under `vtcn-daemon/tests/unit/`
+- Integration tests live under `vtcn-daemon/tests/integration/`
+- Prefer one feature area per test file:
+  - `HostPulseSourceTests.cpp`
+  - `GapDetectorTests.cpp`
+  - `RpmEstimatorTests.cpp`
+  - `FrameEncoderTests.cpp`
+  - `Phase0RuntimeTests.cpp`
+
+## Tolerance Guidance
+
+- Prefer explicit tolerance windows over exact equality for derived numerical outputs
+- Document why a tolerance is acceptable
+- Keep tolerance tight enough to catch real regressions
+
+## CI Expectations
+
+At minimum, CI should run:
+- configure
+- build
+- test
+
+Nice to have if low risk:
+- sanitizer job
+- format or lint check

--- a/docs/readme-old.md
+++ b/docs/readme-old.md
@@ -1,0 +1,476 @@
+# VTCN – Vehicle Telemetry & Control Node
+
+Embedded Linux telemetry platform built on the **BeagleBone Black (ARM Cortex‑A8)**.
+
+This project is intentionally structured as a **production‑style embedded systems engineering exercise**. All features must be implemented and validated on real hardware. No simulated claims.
+
+VTCN is also designed to integrate with the **Edge AI Diagnostics Platform**, which consumes telemetry streams for analysis, diagnostics, and automation workflows.
+
+---
+
+# Project Purpose
+
+VTCN exists to demonstrate real-world embedded Linux competencies while providing a telemetry node suitable for robotics, automotive, and aerospace-style systems.
+
+Core competencies demonstrated:
+
+- ARM-based Linux bring-up
+- Cross-compilation workflows (x86 → ARM)
+- Hardware interface validation (GPIO, I2C, SPI, UART, ADC)
+- Telemetry protocol design
+- Structured logging (SQLite)
+- TCP telemetry streaming
+- Low-level debugging (gdb, strace, perf, dmesg)
+- Linux kernel module development
+- systemd service hardening
+- Reproducible builds and validation procedures
+
+The platform is also intended to support **real vehicle telemetry work**, beginning with the OM606 engine swap project (TPS and coolant telemetry).
+
+---
+
+# Relationship to the Edge AI Diagnostics Platform
+
+VTCN acts as a **telemetry acquisition and transport node** for the Edge AI Diagnostics Platform.
+
+Architecture relationship:
+
+```
+Physical Sensors
+      │
+      ▼
+HAL (BBB / MCU)
+      │
+      ▼
+VTCN Telemetry Daemon
+      │
+      ├── SQLite Local Logging
+      │
+      └── TCP Telemetry Stream
+              │
+              ▼
+Edge AI Diagnostics Platform
+              │
+              ▼
+Diagnostics / Analysis / Automation
+```
+
+The **Edge AI Diagnostics Platform** is responsible for:
+
+- signal analysis
+- anomaly detection
+- system diagnostics
+- telemetry visualization
+
+The **contract between VTCN and the Edge AI Diagnostics Platform** is defined in:
+
+```
+docs/interfaces/edge_ai_diagnostics_contract.md
+```
+
+This contract defines:
+
+- telemetry frame format
+- message versioning
+- CRC integrity checks
+- transport expectations
+- compatibility guarantees
+
+VTCN must follow this contract strictly to ensure interoperability.
+
+---
+
+# Development Principles
+
+## Hardware‑First Validation
+
+Every subsystem must be tested and documented on the **BeagleBone Black hardware**.
+
+## Reproducibility
+
+All builds, deployments, and validation procedures must be reproducible from a clean environment.
+
+## Modular Architecture
+
+System responsibilities are intentionally separated:
+
+| Component | Responsibility |
+|--------|--------|
+| HAL | hardware I/O only |
+| Telemetry Daemon | filtering, calibration, framing, networking |
+| Protocol | versioned message format |
+| MCU Coprocessor | deterministic signal capture |
+
+## Evidence‑Driven Engineering
+
+Each phase requires:
+
+- logs
+- validation output
+- documented procedures
+
+Evidence is stored under:
+
+```
+docs/test-results/
+```
+
+---
+
+# Repository Structure
+
+```
+vtcn/
+
+  README.md
+  CMakeLists.txt
+
+  docs/
+    architecture/
+      system_overview.md
+      component_boundaries.md
+      data_flow.md
+      failure_modes.md
+
+    interfaces/
+      hal_adc.md
+      hal_gpio.md
+      hal_i2c.md
+      hal_spi.md
+      hal_uart.md
+      mcu_protocol.md
+      telemetry_protocol.md
+      edge_ai_diagnostics_contract.md
+
+    procedures/
+      beaglebone_bringup.md
+      cross_compile_setup.md
+      virtual_development_mode.md
+      adc_validation.md
+      debugging_workflow.md
+
+    adr/
+      ADR-001-hal-separation.md
+      ADR-002-telemetry-framing.md
+      ADR-003-mcu-coprocessor.md
+
+    ai/
+      ai_context.md
+      ai_rules.md
+      project_summary.md
+
+    test-results/
+
+  toolchain/
+    beaglebone-gcc.cmake
+    build.sh
+    deploy.sh
+
+  vtcn-daemon/
+    CMakeLists.txt
+
+    include/
+      vtcn/
+        hal/
+        telemetry/
+        logging/
+        storage/
+        net/
+        config/
+
+    src/
+
+    tests/
+      unit/
+      integration/
+      fixtures/
+
+  mcu-node/
+    firmware/
+    protocol/
+    test-tools/
+
+  proto/
+
+  schema/
+
+  systemd/
+
+  lkm/
+```
+
+---
+
+# Testing Strategy
+
+Testing in VTCN is divided into three categories.
+
+## Unit Tests
+
+Framework:
+
+```
+GoogleTest
+```
+
+Purpose:
+
+- validate pure logic
+- config parsing
+- frame encoding/decoding
+- CRC calculation
+
+Location:
+
+```
+vtcn-daemon/tests/unit/
+```
+
+## Integration Tests
+
+Purpose:
+
+- verify module interaction
+- daemon startup validation
+- protocol round-trip checks
+
+Location:
+
+```
+vtcn-daemon/tests/integration/
+```
+
+## Hardware Validation
+
+Hardware interfaces cannot be fully tested on host systems.
+
+Instead:
+
+- validation tools are created
+- procedures are documented
+- evidence is recorded
+
+Documentation:
+
+```
+docs/procedures/
+```
+
+Evidence:
+
+```
+docs/test-results/
+```
+
+## Host-Side Baseline
+
+During Phase 0 Virtual Development Mode, the host-only scaffold can be checked with:
+
+```
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+These commands validate build wiring and host-side test scaffolding only. They do not constitute hardware validation on the BeagleBone Black.
+
+---
+
+# MCU Coprocessor (Arduino / Future STM32)
+
+The BeagleBone Black remains the **primary embedded Linux platform**.
+
+The MCU node acts as a **real-time coprocessor**.
+
+### Responsibilities
+
+- capture high-frequency pulse inputs
+- deterministic timing via hardware timers
+- analog signal conditioning
+- watchdog functionality
+
+### Architectural Rule
+
+```
+MCU = real-time acquisition
+BBB = system orchestration
+```
+
+The MCU must never replace Linux application logic.
+
+---
+
+# Phase Roadmap
+
+## Phase 1 – Platform Foundation
+
+Objective:
+
+Establish a stable ARM Linux development target.
+
+Deliverables:
+
+- Debian image flashed and boot validated
+- SSH secured (key-only authentication)
+- serial console operational
+- documentation of boot process and exposed interfaces
+
+Evidence Required:
+
+```
+uname -a
+
+dmesg
+
+/sys and /dev listings
+```
+
+---
+
+## Phase 2 – Toolchain & Cross‑Compilation
+
+Objective:
+
+Build reproducible host → ARM workflow.
+
+Deliverables:
+
+- ARM cross compiler installed
+- CMake toolchain configuration
+- deploy scripts
+- cross‑compiled binary running on BBB
+
+---
+
+## Phase 3 – Hardware Interface Layer (HAL)
+
+Interfaces:
+
+- ADC (IIO)
+- GPIO
+- I2C
+- SPI
+- UART
+
+Deliverables:
+
+- HAL modules
+- validation tools
+- calibration documentation
+
+---
+
+## Phase 4 – Debugging & Observability
+
+Tools:
+
+- gdb
+- strace
+- perf
+- dmesg
+
+---
+
+## Phase 5 – Kernel Module
+
+Deliverables:
+
+- loadable kernel module
+- `/dev/vtcn` device
+- read/write interface
+
+---
+
+## Phase 6 – Productionization
+
+Deliverables:
+
+- systemd service
+- watchdog integration
+- structured logging
+
+---
+
+## Phase 7 – Yocto Migration
+
+Deliverables:
+
+- Yocto image
+- custom recipe for daemon
+- reproducible build steps
+
+---
+
+# Telemetry Architecture
+
+High-Level Flow
+
+```
+Sensors
+   │
+   ▼
+HAL Layer
+   │
+   ▼
+Telemetry Daemon
+   │
+ ┌─┴───────────┐
+ ▼             ▼
+SQLite        TCP Stream
+                 │
+                 ▼
+       Edge AI Diagnostics Platform
+```
+
+Telemetry frames must include:
+
+- magic number
+- protocol version
+- monotonic timestamp
+- payload length
+- CRC32
+
+Protocol definitions are stored under:
+
+```
+docs/interfaces/
+```
+
+---
+
+# Definition of Success
+
+VTCN is considered successful when:
+
+- it runs reliably on ARM hardware
+- it acquires real sensor data
+- hardware interfaces are validated
+- telemetry streams reach the Edge AI Diagnostics Platform
+- services run under systemd
+- procedures allow reproducible deployment
+
+---
+
+# Current Status
+
+Phase: **Virtual Development Mode (Phase 0)**
+
+Next Action:
+
+1. Continue host-side scaffolding, interface work, and pure-logic tests
+2. Prepare Phase 1 bring-up and validation procedures
+3. Defer BeagleBone Black hardware claims until target evidence exists
+
+---
+
+# Author Intent
+
+This project is designed to serve as a **portfolio‑grade embedded systems platform** demonstrating:
+
+- embedded Linux platform engineering
+- hardware interface development
+- telemetry system architecture
+- debugging and validation workflows
+- professional engineering documentation
+
+The project intentionally mirrors practices used in aerospace, robotics, and advanced automotive embedded systems development.

--- a/vtcn_governance_docs.md
+++ b/vtcn_governance_docs.md
@@ -1,0 +1,406 @@
+# VTCN Governance Docs
+
+Below are adapted versions of `REVIEWING.md`, `TESTING.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md` tailored for the VTCN C++ systems project.
+
+---
+
+# REVIEWING.md
+
+```md
+# Reviews (VTCN)
+
+## Review Checklist
+
+### Scope & Architecture
+- Does this change only what the issue intended?
+- Are module boundaries respected?
+  - host-side pulse source / simulation
+  - daemon processing
+  - protocol framing
+  - docs / build / CI
+- Does the implementation align with current ADRs and Phase 0 constraints?
+- Does the change avoid making unsupported hardware claims?
+- Is the current slice still honest about Virtual Development Mode?
+
+### Correctness
+- Are timing units explicit and consistent?
+  - prefer monotonic timestamps in integer microseconds or clearly documented equivalents
+- Is 36-1 wheel behavior modeled correctly?
+- Is the missing-tooth gap represented and detected correctly?
+- Is RPM estimation derived from the correct interval set?
+- Are tolerance thresholds documented and justified?
+- Are boundary conditions handled?
+  - empty pulse list
+  - too few samples
+  - malformed intervals
+  - jitter/noise cases
+
+### Modern C++ / Design Quality
+- Does the code use modern C++23 features where they improve clarity or correctness?
+- Are types strong enough to avoid primitive confusion?
+- Is const-correctness respected?
+- Are interfaces small and purposeful?
+- Is logic testable, with pure functions where practical?
+- Is the design simple enough for the current project stage, without unnecessary abstraction?
+
+### Quality & Maintainability
+- Warnings are enabled and the code builds cleanly
+- Error handling is explicit and reasonable
+- Naming is clear and consistent
+- Logging/output is useful for debugging but not noisy
+- Comments explain intent, not obvious syntax
+- New code fits the repo structure and current architecture
+
+### Testing & Tooling
+- Unit tests added/updated for new logic
+- Integration coverage exists for the end-to-end Phase 0 path where appropriate
+- CI passes for build and tests
+- New behavior includes at least one deterministic test
+- Sanitizers or extra checks are used where practical and not destabilizing
+
+### Docs & Evidence Discipline
+- README/current-state docs were updated if behavior changed
+- Design notes reflect what is actually implemented now
+- Future work is clearly separated from current capability
+- No AI-generated/speculative docs remain in active paths unless clearly labeled
+- Reviewers can understand how to build, run, and test the current slice
+
+## When to Request Changes
+
+Request changes if:
+- The PR exceeds the issue scope without a strong reason
+- Architecture boundaries are blurred or violated
+- Host-side work is written as if it proves hardware integration
+- Tests were not added for new logic
+- Timing assumptions or thresholds are unexplained
+- Protocol/wire format changes happened without updating docs/ADR references
+- CI/build tooling broke or is undocumented
+- The repo now oversells implemented capability
+
+## "Good Enough" Standard
+
+This is a systems/embedded-adjacent C++ project.
+Prioritize:
+- correctness
+- determinism at boundaries
+- honest evidence
+- clean modular design
+- testability
+- clarity over cleverness
+```
+
+---
+
+# TESTING.md
+
+```md
+# Testing (VTCN)
+
+This project uses CMake + CTest with GoogleTest for unit and integration testing.
+
+## Goals
+- Unit test all new or changed logic.
+- Keep tests deterministic and fast.
+- Prefer pure functions or narrowly scoped classes for signal processing logic.
+- Validate host-side behavior honestly without implying hardware validation.
+
+## Commands
+- Configure:
+  - `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
+- Build:
+  - `cmake --build build`
+- Run tests:
+  - `ctest --test-dir build --output-on-failure`
+- Optional verbose test run:
+  - `ctest --test-dir build -V`
+
+If presets are added later, document those commands here.
+
+## What Must Be Unit Tested
+
+Minimum expectations for new logic:
+- Signal generation behavior:
+  - correct pulse count for 36-1 wheel
+  - monotonic timestamp ordering
+  - one oversized gap interval per revolution
+- Gap detection behavior:
+  - detects missing-tooth gap on clean input
+  - remains stable under light jitter/noise
+- RPM estimation behavior:
+  - estimated RPM remains within a documented tolerance window
+  - gap interval is excluded or handled intentionally
+  - malformed/insufficient data is handled safely
+- Protocol framing / CRC behavior (if included in the current slice)
+- Argument/config parsing for runtime/demo behavior
+
+## Integration Tests
+Allowed and encouraged when they remain fast.
+
+Examples:
+- Full pipeline: host pulse source -> gap detection -> RPM estimation
+- Phase 0 runtime smoke test
+- Optional frame encode/decode round trip if protocol framing is implemented
+
+Avoid:
+- Tests that require BeagleBone hardware
+- Tests that require MCU hardware
+- Tests that require real network services
+- Tests that depend on wall-clock timing
+- Slow, flaky, or nondeterministic tests
+
+## Test Structure
+- Unit tests live under:
+  - `vtcn-daemon/tests/unit/`
+- Integration tests live under:
+  - `vtcn-daemon/tests/integration/`
+- Prefer one feature area per test file:
+  - `HostPulseSourceTests.cpp`
+  - `GapDetectorTests.cpp`
+  - `RpmEstimatorTests.cpp`
+  - `FrameEncoderTests.cpp`
+  - `Phase0RuntimeTests.cpp`
+
+## Tolerance Guidance
+- Prefer explicit tolerance windows over exact equality for derived numerical outputs
+- Document why a tolerance is acceptable
+- Keep tolerance tight enough to catch real regressions
+
+## CI Expectations
+At minimum, CI should run:
+- configure
+- build
+- test
+
+Nice to have if low risk:
+- sanitizer job
+- format/lint check
+```
+
+---
+
+# CONTRIBUTING.md
+
+```md
+# Contributing to VTCN
+
+VTCN follows disciplined change control to keep the project readable, maintainable,
+and technically honest. The repo should reflect what is implemented now, what is host-side only,
+and what is planned for later phases.
+
+Codex or other AI tools may assist with implementation, but all changes must follow these conventions.
+
+---
+
+# Git Commit Guidelines
+
+Each commit message consists of:
+- Header (required)
+- Body (strongly encouraged)
+- Footer (optional)
+
+No line may exceed 100 characters.
+
+## Commit Message Format
+
+`type(scope): subject`
+
+Body (optional but strongly encouraged)
+Footer (optional)
+
+The header is mandatory.
+The scope is required for this project.
+
+## Revert
+If reverting a commit:
+
+`revert(scope): subject`
+
+Body should include:
+`This reverts commit <sha>.`
+
+## Type
+Must be one of:
+- `feat`: a new feature
+- `fix`: a bug fix
+- `refactor`: code change without feature or bug fix
+- `perf`: performance improvement
+- `test`: add or update tests
+- `docs`: documentation-only changes
+- `style`: formatting only (no logic changes)
+- `chore`: tooling, build, or dependency changes
+- `ci`: CI/CD workflow changes
+
+## Scope
+Scope describes the subsystem affected.
+
+Approved scopes for VTCN:
+- `daemon` daemon runtime / orchestration
+- `signal` pulse generation and timing logic
+- `rpm` estimation logic
+- `protocol` telemetry framing / encoding / decoding
+- `crc` checksum logic
+- `hal` hardware abstraction boundaries
+- `mcu` MCU-side concepts or firmware-facing work
+- `schema` schemas / payload definitions
+- `toolchain` compiler / standard / build settings
+- `build` CMake and build configuration
+- `test` test code or test harness changes
+- `docs` documentation updates
+- `repo` repository structure changes
+- `ci` CI workflows
+- `systemd` service files / ops plumbing
+- `phase0` virtual development mode implementation slice
+
+Use lowercase.
+
+## Examples
+- `feat(signal): add 36-1 pulse generation`
+- `feat(rpm): estimate rpm from tooth intervals`
+- `test(phase0): add end-to-end runtime coverage`
+- `chore(toolchain): migrate project to c++23`
+- `ci(build): add cmake build-and-test workflow`
+
+## Subject Rules
+The subject must:
+- use imperative present tense (`add`, not `added`)
+- not capitalize the first letter
+- not end with a period
+- be concise and descriptive
+
+Correct:
+- `add monotonic pulse generation`
+- `enforce c++23 across daemon targets`
+- `archive speculative docs for later phases`
+
+Incorrect:
+- `Added pulse generation.`
+- `Fixes stuff.`
+
+## Body
+Use imperative tense.
+Explain:
+- what changed
+- why it changed
+- how it differs from previous behavior
+
+Keep lines under 100 characters.
+
+Example:
+
+Add a host-side 36-1 pulse source for Phase 0 validation.
+Previously the repo documented the signal path but did not provide
+an implemented, testable source of deterministic pulse events.
+This adds timestamped pulses with optional light jitter for daemon-side processing.
+
+Closes #12
+
+## Footer
+Used for:
+- issue references: `Closes #12`, `Refs #14`
+- breaking changes: must begin with `BREAKING CHANGE:`
+
+---
+
+# Branching Strategy
+
+- One branch per issue when practical
+- Branch name format:
+  - `issue/<number>-short-description`
+
+Examples:
+- `issue/7-cpp23-migration`
+- `issue/9-signal-generator`
+- `issue/12-ci-build-test`
+
+Rules:
+- Merge via Pull Request
+- Keep PRs scoped and reviewable
+- Do not push directly to `main`
+- Before external submission, ensure `main` reflects the sendable state or clearly document the review branch
+
+---
+
+# Code Style
+
+## Language / Standard
+- C++23 for active targets
+- Prefer the standard library over ad hoc utilities where practical
+- Use modern features when they improve correctness, readability, or maintainability
+
+## Design Guidance
+- Prefer clear value types and small classes
+- Keep module responsibilities narrow
+- Use pure functions where possible for core signal/rpm logic
+- Avoid unnecessary inheritance or abstraction in Phase 0
+- Separate internal runtime types from wire/protocol formats
+
+## Naming
+- Files: `PascalCase` or project-consistent naming, but be consistent
+- Types/classes: `PascalCase`
+- Functions/variables: `snake_case` or project-consistent lower style, but be consistent
+- Constants: `kCamelCase` or `UPPER_SNAKE_CASE` if already standardized
+
+## Error Handling
+- Be explicit and predictable
+- Avoid silent failure
+- Prefer returning structured status/results where appropriate
+- Do not use exceptions for ordinary control flow unless the project explicitly adopts that model
+
+## Logging / Output
+- Output should help a reviewer understand current runtime behavior
+- Keep logs concise and deterministic
+- Do not overclaim what the runtime proves
+
+## Architecture Honesty
+- Do not label host-side simulation as hardware validation
+- Do not blur HAL responsibilities with daemon policy/processing
+- Keep future-facing docs clearly separated from implemented behavior
+
+---
+
+# Security / Safety Basics
+
+- No secrets in git
+- No fabricated validation claims
+- External interfaces and payload formats must be documented if added
+- Changes to protocol framing should be reflected in docs and associated design notes
+
+---
+
+# Repo Discipline
+
+Before opening a PR, ask:
+- Does this reflect what the repo can actually do now?
+- Can I explain this confidently in an interview?
+- Did I add tests for the logic I changed?
+- Did I keep the scope narrow enough to review quickly?
+```
+
+---
+
+# .github/pull_request_template.md
+
+```md
+## What changed
+-
+
+## Why
+-
+
+## Architecture / ADR impact
+- [ ] Boundary ownership preserved
+- [ ] Virtual Development Mode assumptions still accurate
+- [ ] Docs updated if implemented behavior changed
+
+## How to test
+- [ ] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
+- [ ] `cmake --build build`
+- [ ] `ctest --test-dir build --output-on-failure`
+- [ ] Manual check:
+
+## Reviewer notes
+- Phase touched:
+- Key tradeoffs:
+- Known follow-up work:
+```
+

--- a/vtcn_milestones_and_github_issues.md
+++ b/vtcn_milestones_and_github_issues.md
@@ -1,0 +1,605 @@
+# VTCN Milestones And GitHub Issues
+
+This document converts the weekend plan into GitHub-ready milestones, feature buckets, and issue cards.
+
+The active submission target is Monday, March 23, 2026.
+
+## Planning Intent
+
+Use this file to:
+- create GitHub milestones
+- group issues under a few clear feature areas
+- keep the repo focused on the Phase 0 host-side sample
+- preserve the larger architecture plan without pulling future work into this weekend
+
+## Recommended GitHub Labels
+
+Core labels:
+- `phase0`
+- `submission`
+- `architecture`
+- `signal-processing`
+- `tooling`
+- `testing`
+- `documentation`
+- `ci`
+- `optional`
+- `future`
+
+Priority labels:
+- `p0`
+- `p1`
+- `p2`
+
+Status labels if wanted:
+- `blocked`
+- `ready`
+- `in-progress`
+- `review`
+
+## Milestones
+
+### Milestone 1: Monday Submission - Phase 0 Host Signal Pipeline
+
+Due date:
+- March 23, 2026
+
+Goal:
+- deliver a clean, discussable, host-side prototype inside `vtcn-daemon`
+- demonstrate 36-1 pulse simulation, gap detection, RPM estimation, tests, build tooling, and honest docs
+
+Exit criteria:
+- repo scope and README are technically honest
+- active daemon targets build locally
+- tests pass locally
+- CI build-and-test workflow exists
+- Phase 0 runtime demo is present
+- code and docs align with current ADRs
+
+Included work:
+- all `p0` and `p1` issues in this document except explicitly marked optional
+
+### Milestone 2: Post-Submission Hardening And Protocol Slice
+
+Due date:
+- no date yet
+
+Goal:
+- harden the host-side prototype after submission without expanding into hardware work
+
+Exit criteria:
+- optional telemetry framing is complete and tested
+- warning baseline is stricter
+- sample artifacts are cleaner
+- docs reflect the more complete host-side slice
+
+Included work:
+- optional framing
+- sanitizers if low friction
+- extra integration coverage
+
+### Milestone 3: Hardware Integration Prep
+
+Due date:
+- no date yet
+
+Goal:
+- prepare for BBB and MCU work without making unsupported claims
+
+Exit criteria:
+- hardware-facing interfaces are documented and narrowed
+- bring-up procedures are realistic
+- host-side assumptions are documented for target validation
+
+Included work:
+- HAL stubs and interface docs
+- bring-up planning
+- target evidence plan
+
+## Feature Buckets
+
+These are the best GitHub "feature" or epic-level buckets for the current repo.
+
+### Feature A: Phase 0 Scope And Architecture Credibility
+
+Why it exists:
+- the repo already has architecture intent, but the active story needs to match current evidence
+
+Included work:
+- README correction
+- active doc audit
+- architecture conformance pass
+- directory ownership decisions
+
+### Feature B: Host-Side Crank Signal Pipeline
+
+Why it exists:
+- this is the actual technical centerpiece for Monday
+
+Included work:
+- HostPulseSource
+- GapDetector
+- RpmEstimator
+- Phase0Runtime CLI
+
+### Feature C: Quality Gates And Tooling
+
+Why it exists:
+- strong reviewer signal comes from build cleanliness, tests, and CI
+
+Included work:
+- C++23 migration
+- warnings
+- formatter
+- unit tests
+- integration tests
+- GitHub Actions
+
+### Feature D: Optional Telemetry Framing
+
+Why it exists:
+- framing is a credible systems addition, but only after the core signal pipeline is finished
+
+Included work:
+- frame encoder
+- CRC32
+- framing tests
+- short design note
+
+## Active Weekend Issues
+
+Create these under Milestone 1 unless marked otherwise.
+
+### Issue 01
+
+Title:
+- `Audit repo scope and active docs for Phase 0 honesty`
+
+Summary:
+- reconcile README, active docs, and virtual-development guidance so the repo presents a truthful Phase 0 story
+
+Why it matters:
+- this is a credibility issue, not cosmetic cleanup
+
+Acceptance criteria:
+- top-level README separates current state from long-term roadmap
+- active docs do not claim host-side work proves hardware validation
+- speculative or AI-heavy material is archived, relabeled, or removed from active paths
+- `docs/procedures/virtual_development_mode.md` stays consistent with the repo story
+
+Labels:
+- `phase0`
+- `submission`
+- `documentation`
+- `architecture`
+- `p0`
+
+Dependencies:
+- none
+
+Estimate:
+- 2 hours
+
+### Issue 02
+
+Title:
+- `Migrate active daemon targets to C++23`
+
+Summary:
+- upgrade active build targets from C++17 to C++23 and keep the standard consistent across library, CLI, and tests
+
+Acceptance criteria:
+- top-level CMake requests C++23
+- `vtcn-daemon` targets inherit or require C++23
+- local build succeeds after migration
+- no unnecessary language feature churn is introduced just because C++23 is available
+
+Labels:
+- `phase0`
+- `tooling`
+- `p0`
+
+Dependencies:
+- Issue 01 recommended first
+
+Estimate:
+- 1 hour
+
+### Issue 03
+
+Title:
+- `Add warning baseline for GCC Clang and MSVC`
+
+Summary:
+- enable useful compiler warnings now while the codebase is still small
+
+Acceptance criteria:
+- warnings are enabled in CMake for active targets
+- build is clean under the current local compiler
+- warning policy is documented briefly if needed
+
+Labels:
+- `phase0`
+- `tooling`
+- `p0`
+
+Dependencies:
+- Issue 02
+
+Estimate:
+- 1 hour
+
+### Issue 04
+
+Title:
+- `Add clang-format baseline for active C++ files`
+
+Summary:
+- establish formatting early so the weekend does not produce noisy style churn
+
+Acceptance criteria:
+- `.clang-format` exists at repo root
+- active `vtcn-daemon` code is formatted consistently
+- inactive or archived content is not reformatted unnecessarily
+
+Labels:
+- `tooling`
+- `submission`
+- `p1`
+
+Dependencies:
+- Issue 02
+
+Estimate:
+- 45 minutes
+
+### Issue 05
+
+Title:
+- `Define Phase 0 daemon structure and core runtime types`
+
+Summary:
+- create the exact file layout and runtime types for the host-side signal pipeline before filling in the logic
+
+Acceptance criteria:
+- `vtcn-daemon` has clear locations for source, processing, runtime, and optional protocol code
+- internal runtime types are separate from future wire-format types
+- stubs compile before feature logic is added
+- ownership aligns with ADR-001 and ADR-002
+
+Labels:
+- `phase0`
+- `architecture`
+- `p0`
+
+Dependencies:
+- Issue 02
+- Issue 03 recommended
+
+Estimate:
+- 2 hours
+
+### Issue 06
+
+Title:
+- `Implement HostPulseSource for 36-1 crank pulse simulation`
+
+Summary:
+- generate deterministic monotonic pulse timestamps for a 36-1 wheel at configurable RPM and revolution count
+
+Acceptance criteria:
+- emits 35 pulses per revolution
+- timestamps are strictly increasing
+- one missing-tooth gap interval appears per revolution
+- integer time units are explicit
+- behavior is deterministic for identical inputs
+
+Labels:
+- `phase0`
+- `signal-processing`
+- `p0`
+
+Dependencies:
+- Issue 05
+
+Estimate:
+- 3 hours
+
+### Issue 07
+
+Title:
+- `Implement gap detection for missing-tooth interval`
+
+Summary:
+- derive intervals from ordered pulses and identify the missing-tooth gap with a simple, defensible method
+
+Acceptance criteria:
+- works on clean data
+- remains stable under light jitter
+- insufficient input returns a clear failure result
+- output includes enough information for runtime reporting and tests
+
+Labels:
+- `phase0`
+- `signal-processing`
+- `p0`
+
+Dependencies:
+- Issue 06
+
+Estimate:
+- 2.5 hours
+
+### Issue 08
+
+Title:
+- `Implement RPM estimator from tooth intervals`
+
+Summary:
+- compute RPM from nominal tooth intervals while excluding the missing-tooth gap from the estimate
+
+Acceptance criteria:
+- estimates RPM within a documented tolerance for multiple target RPM values
+- handles malformed and insufficient data safely
+- algorithm assumptions are simple enough to explain in an interview
+
+Labels:
+- `phase0`
+- `signal-processing`
+- `p0`
+
+Dependencies:
+- Issue 07
+
+Estimate:
+- 2.5 hours
+
+### Issue 09
+
+Title:
+- `Integrate Phase0Runtime CLI demo`
+
+Summary:
+- build a small CLI around the source, detector, and estimator so reviewers can run the full slice end to end
+
+Acceptance criteria:
+- CLI has a small documented argument set
+- `--help` is current and honest
+- output shows target RPM, estimated RPM, and gap detection summary
+- runtime states clearly that it is host-side Phase 0 validation
+
+Labels:
+- `phase0`
+- `submission`
+- `p0`
+
+Dependencies:
+- Issue 08
+
+Estimate:
+- 2 hours
+
+### Issue 10
+
+Title:
+- `Add unit tests for signal generation gap detection and RPM estimation`
+
+Summary:
+- build deterministic unit coverage around the core processing logic
+
+Acceptance criteria:
+- tests verify pulse count per revolution
+- tests verify monotonic timestamps
+- tests verify one oversized gap per revolution
+- tests verify gap detection on clean input and light jitter
+- tests verify RPM estimation tolerance at several RPM values
+
+Labels:
+- `phase0`
+- `testing`
+- `p0`
+
+Dependencies:
+- Issue 06
+- Issue 07
+- Issue 08
+
+Estimate:
+- 3 hours
+
+### Issue 11
+
+Title:
+- `Add Phase 0 end-to-end integration tests`
+
+Summary:
+- verify the host-side pipeline works as a whole without relying on hardware
+
+Acceptance criteria:
+- integration test exercises source to estimator path
+- CLI or runtime smoke test remains fast and deterministic
+- tests are runnable through CTest
+
+Labels:
+- `phase0`
+- `testing`
+- `p1`
+
+Dependencies:
+- Issue 09
+- Issue 10
+
+Estimate:
+- 1.5 hours
+
+### Issue 12
+
+Title:
+- `Add GitHub Actions build-and-test workflow`
+
+Summary:
+- add the minimum worthwhile CI signal for an external reviewer
+
+Acceptance criteria:
+- Linux workflow configures, builds, and runs tests
+- workflow uses documented commands
+- badge or status reference is easy to share later if desired
+
+Labels:
+- `ci`
+- `tooling`
+- `submission`
+- `p0`
+
+Dependencies:
+- Issue 10
+- Issue 11 recommended
+
+Estimate:
+- 1.5 hours
+
+### Issue 13
+
+Title:
+- `Rewrite README current-state section and add Phase 0 design note`
+
+Summary:
+- ensure reviewers can understand the implemented slice, build it, run it, and understand what has not yet been validated
+
+Acceptance criteria:
+- README has accurate current-state and roadmap sections
+- build and test commands are correct
+- sample run command is documented
+- design note explains simulation, gap detection, and RPM estimation at a high level
+
+Labels:
+- `documentation`
+- `submission`
+- `phase0`
+- `p0`
+
+Dependencies:
+- Issue 09
+- Issue 10
+- Issue 12 recommended
+
+Estimate:
+- 2 hours
+
+### Issue 14
+
+Title:
+- `Run architecture conformance review before Monday submission`
+
+Summary:
+- do one last pass focused on boundary discipline, evidence discipline, and interview-readiness
+
+Acceptance criteria:
+- active code and docs align with ADR-001 and ADR-002
+- no file overclaims validation status
+- repo story is consistent across README, docs, code comments, and CLI output
+- final branch and send strategy are chosen
+
+Labels:
+- `architecture`
+- `submission`
+- `p0`
+
+Dependencies:
+- Issues 01 through 13
+
+Estimate:
+- 1.5 hours
+
+## Optional Weekend Issue
+
+Only create this if Milestone 1 is already stable.
+
+### Issue 15
+
+Title:
+- `Add optional telemetry frame encoder and CRC32 for Phase 0 output`
+
+Summary:
+- package runtime output into a small versioned frame without confusing internal runtime types with wire format types
+
+Acceptance criteria:
+- frame structure includes version, timestamp, payload length, and CRC32
+- encoder is tested
+- framing is documented as host-side only
+- implementation does not disrupt the core pipeline schedule
+
+Labels:
+- `phase0`
+- `optional`
+- `signal-processing`
+- `p2`
+
+Milestone:
+- Milestone 2 preferred unless finished early
+
+Dependencies:
+- Issue 09
+- Issue 10
+- Issue 13
+
+Estimate:
+- 3 hours
+
+## Recommended Creation Order
+
+Create milestones first:
+1. Monday Submission - Phase 0 Host Signal Pipeline
+2. Post-Submission Hardening And Protocol Slice
+3. Hardware Integration Prep
+
+Then create issues in this order:
+1. Issue 01
+2. Issue 02
+3. Issue 03
+4. Issue 05
+5. Issue 06
+6. Issue 07
+7. Issue 08
+8. Issue 09
+9. Issue 10
+10. Issue 11
+11. Issue 12
+12. Issue 13
+13. Issue 14
+14. Issue 04
+15. Issue 15 only if time remains
+
+Why Issue 04 is later in creation order:
+- it is useful, but not on the critical path to a correct Monday sample
+
+Why Issue 15 is separate:
+- framing is a strong enhancement, but not stronger than finishing the core signal-processing slice cleanly
+
+## Minimum Monday Deliverable
+
+If time gets tight, the true minimum acceptable Monday package is:
+- Issue 01
+- Issue 02
+- Issue 03
+- Issue 05
+- Issue 06
+- Issue 07
+- Issue 08
+- Issue 10
+- Issue 11
+- Issue 12
+- Issue 13
+- Issue 14
+
+The first thing to cut is:
+- Issue 15
+
+The second thing to relax, if absolutely necessary:
+- full formatter rollout from Issue 04
+
+Do not cut:
+- README honesty
+- tests
+- buildability
+- the end-to-end runtime demo

--- a/vtcn_weekend_sprint_issue_pack.md
+++ b/vtcn_weekend_sprint_issue_pack.md
@@ -1,0 +1,312 @@
+# VTCN Weekend Sprint Issue Pack
+
+This pack is scoped to a Monday-submittable Phase 0 sample inside the existing VTCN repo.
+
+Target outcome:
+- a host-side only 36-1 crank pulse simulation
+- gap detection
+- RPM estimation
+- a small CLI runtime
+- real tests
+- clean CMake and CI
+- honest docs aligned to current ADRs
+
+Non-goals for this sprint:
+- BeagleBone hardware access
+- MCU firmware work
+- networking
+- SQLite or storage
+- protobuf
+- daemon install or service work
+- QEMU or kernel work
+
+## Recommended Execution Order
+
+1. Issue 01: audit repo scope and active docs
+2. Issue 02: migrate active targets to C++23 and warnings
+3. Issue 03: add formatting baseline
+4. Issue 04: lock Phase 0 structure and core types
+5. Issue 05: implement HostPulseSource
+6. Issue 06: implement GapDetector
+7. Issue 07: implement RpmEstimator
+8. Issue 08: integrate Phase0Runtime CLI demo
+9. Issue 09: add unit and integration tests
+10. Issue 10: add GitHub Actions build and test workflow
+11. Issue 11: README and design note cleanup
+12. Issue 12: architecture conformance and Monday send audit
+13. Issue 13: telemetry frame encoder and CRC, only if Issues 01-12 are complete
+
+## Issue 01: Audit Repo Scope And Active Docs
+
+Summary:
+Trim or relabel speculative material so the repo reads as disciplined and current. The active repo story
+must be "Phase 0 host-side validation slice inside a broader architecture" rather than "already validated
+embedded product."
+
+Acceptance criteria:
+- README no longer claims all features require real hardware today
+- active docs clearly distinguish current host-side validation from future hardware validation
+- speculative or AI-heavy docs are archived, removed, or clearly labeled as non-active
+- `docs/procedures/virtual_development_mode.md` is consistent with the current repo story
+
+Dependencies:
+- none
+
+Estimated effort:
+- 1.5 to 2.5 hours
+
+Notes:
+- This is first because credibility matters more than adding features to a misleading repo
+
+## Issue 02: Migrate Active Targets To C++23 And Warning Baseline
+
+Summary:
+Move the active daemon slice to C++23 and enable a clean warning posture. This is a strong reviewer signal
+and cheap to finish early.
+
+Acceptance criteria:
+- top-level and daemon CMake targets build as C++23
+- warning flags are enabled for GCC, Clang, and MSVC where practical
+- clean local build completes without new warnings in active targets
+- test targets use the same standard level as production targets
+
+Dependencies:
+- Issue 01 recommended first so the repo narrative is already corrected
+
+Estimated effort:
+- 1 to 1.5 hours
+
+## Issue 03: Add Formatting Baseline
+
+Summary:
+Add a formatter configuration and apply it to the active C++ slice. This is worth doing because the project
+is still small and the diff cost is low.
+
+Acceptance criteria:
+- `.clang-format` exists at repo root
+- active daemon headers, sources, and tests are formatted consistently
+- formatting choices do not create churn in archived or inactive areas
+
+Dependencies:
+- Issue 02
+
+Estimated effort:
+- 0.5 to 1 hour
+
+## Issue 04: Lock Phase 0 Structure And Core Types
+
+Summary:
+Define the exact file layout, type ownership, naming, and boundary rules for the Phase 0 slice before
+filling in logic. This keeps the implementation discussable and prevents architecture drift.
+
+Acceptance criteria:
+- `vtcn-daemon` contains clear module placeholders for source, processing, runtime, and optional framing
+- internal runtime types are separated from any future wire format
+- a short design note documents data flow and ownership
+- empty or stub implementations build after the structure change
+
+Dependencies:
+- Issue 02
+- Issue 03 recommended
+
+Estimated effort:
+- 1.5 to 2 hours
+
+## Issue 05: Implement HostPulseSource For 36-1 Simulation
+
+Summary:
+Implement a deterministic host-side source that emits monotonic pulse timestamps for a 36-1 wheel. The
+missing tooth should be represented as a longer interval, not as a fake pulse.
+
+Acceptance criteria:
+- configurable RPM and revolution count
+- 35 pulse timestamps per revolution
+- timestamps are strictly increasing
+- one oversized gap interval exists per revolution
+- optional light jitter is either implemented deterministically or explicitly deferred
+
+Dependencies:
+- Issue 04
+
+Estimated effort:
+- 3 to 4 hours
+
+## Issue 06: Implement GapDetector
+
+Summary:
+Derive tooth intervals from the ordered timestamps and detect the missing-tooth gap using a simple,
+defensible algorithm.
+
+Acceptance criteria:
+- detects one gap per revolution on clean input
+- remains stable under light jitter
+- returns a structured result, not just a magic index
+- behavior for insufficient input is explicit and testable
+
+Dependencies:
+- Issue 05
+
+Estimated effort:
+- 2 to 3 hours
+
+## Issue 07: Implement RpmEstimator
+
+Summary:
+Estimate RPM from pulse intervals while excluding the missing-tooth gap from the nominal tooth interval.
+
+Acceptance criteria:
+- supports several RPM targets with documented tolerance
+- handles malformed or insufficient input safely
+- documents estimation assumptions
+- implementation remains deterministic and testable
+
+Dependencies:
+- Issue 06
+
+Estimated effort:
+- 2 to 3 hours
+
+## Issue 08: Integrate Phase0Runtime CLI Demo
+
+Summary:
+Wire the source, detector, and estimator into a small executable that demonstrates the full path and prints
+clear, honest output for reviewers.
+
+Acceptance criteria:
+- CLI supports a small, documented argument set
+- output shows target RPM, estimated RPM, detected gap information, and validation scope
+- runtime remains host-side only and says so
+- `--help` output is useful and current
+
+Dependencies:
+- Issue 07
+
+Estimated effort:
+- 2 to 3 hours
+
+## Issue 09: Add Unit And Integration Tests
+
+Summary:
+Cover the signal source, gap detector, estimator, and end-to-end Phase 0 runtime with deterministic tests.
+
+Acceptance criteria:
+- unit tests cover pulse count, monotonicity, and gap shape
+- unit tests cover gap detection on clean input and light jitter
+- unit tests cover RPM estimation at several target RPM values
+- integration test covers the full pipeline
+- tests run locally through CTest without hardware
+
+Dependencies:
+- Issue 08, though some tests should be written alongside Issues 05-07
+
+Estimated effort:
+- 3 to 4 hours
+
+## Issue 10: Add GitHub Actions Build And Test Workflow
+
+Summary:
+Add the smallest CI workflow that gives strong reviewer signal without becoming fragile.
+
+Acceptance criteria:
+- GitHub Actions workflow configures, builds, and runs tests
+- Linux job exists at minimum
+- workflow uses documented commands from README or TESTING.md
+- status is suitable for linking in a Monday submission
+
+Dependencies:
+- Issue 09
+
+Estimated effort:
+- 1 to 2 hours
+
+## Issue 11: README And Design Note Cleanup
+
+Summary:
+Rewrite the active repo story around the implemented Phase 0 slice, build commands, example usage, and
+architecture honesty.
+
+Acceptance criteria:
+- README current-state section is accurate
+- example commands are copy-pasteable
+- sample output is included or reproducible
+- a short design note explains signal generation, gap detection, and RPM estimation
+- future work is clearly separated from current capability
+
+Dependencies:
+- Issue 08
+- Issue 09
+- Issue 10 recommended before final wording
+
+Estimated effort:
+- 2 to 3 hours
+
+## Issue 12: Architecture Conformance And Monday Send Audit
+
+Summary:
+Run a final review pass focused on coherence, evidence discipline, and interview-readiness rather than new
+features.
+
+Acceptance criteria:
+- active code and docs align with ADR-001 and ADR-002
+- no file claims hardware validation that did not happen
+- repo top-level story is consistent across README, docs, CLI help, and tests
+- branch, PR, and submission plan are decided
+- final sample is explainable in under five minutes
+
+Dependencies:
+- Issues 01 through 11
+
+Estimated effort:
+- 1.5 to 2 hours
+
+## Issue 13: Optional Telemetry Frame Encoder And CRC
+
+Summary:
+If the core slice is already complete and stable, add a small versioned telemetry frame encoder plus CRC32.
+This is optional because it can improve systems credibility, but it is not required for a strong Monday sample.
+
+Acceptance criteria:
+- internal runtime types remain separate from wire format types
+- frame includes explicit version, timestamp, payload length, and CRC
+- at least one encode test and one CRC test exist
+- docs label framing as Phase 0 host-side only
+
+Dependencies:
+- Issue 08
+- Issue 09
+- Issue 11
+
+Estimated effort:
+- 2 to 4 hours
+
+## Monday Minimum Deliverable
+
+The minimum acceptable Monday sample is:
+- honest repo scope and cleaned active docs
+- C++23 daemon slice with warnings enabled
+- HostPulseSource, GapDetector, and RpmEstimator implemented
+- Phase0Runtime CLI demo
+- unit and integration tests passing
+- GitHub Actions build and test workflow
+- README and design note updated
+
+If time gets tight, drop Issue 13 first.
+
+## Quality Bars
+
+The sample should be:
+- deterministic
+- bounded in scope
+- easy to build and run
+- explicit about assumptions
+- technically honest about validation
+- easy to discuss in an interview
+
+## Anti-Patterns To Avoid
+
+- pretending host-side simulation proves hardware behavior
+- adding interfaces before a real second implementation exists
+- turning Phase 0 into a networking or storage project
+- using floating-point timestamps for core event ordering
+- hiding assumptions inside undocumented constants
+- broad docs that describe future ambitions as current capability


### PR DESCRIPTION
## What changed
- added repository governance docs: REVIEWING.md, TESTING.md, CONTRIBUTING.md, and a PR template
- archived the original top-level README to docs/readme-old.md
- replaced the top-level README with a clearer current-state plus roadmap structure for Phase 0
- added Phase 0 planning artifacts for sprint issues, milestones, and GitHub tracking
- created the corresponding GitHub milestones and issues for the Monday submission work

## Why
- the repo needed a clearer distinction between long-term architecture intent and current host-side validation status
- the weekend work needed explicit tracking, review discipline, and a focused Phase 0 execution plan

## Architecture / ADR impact
- [x] Boundary ownership preserved
- [x] Virtual Development Mode assumptions still accurate
- [x] Docs updated to better reflect implemented behavior and current scope

## How to test
- [x] cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- [x] cmake --build build
- [ ] ctest --test-dir build --output-on-failure
- [ ] Manual check:

## Reviewer notes
- Phase touched: planning and governance only
- Key tradeoffs: preserved overall roadmap while making the current Phase 0 state explicit
- Known follow-up work: implement the milestone issues beginning with scope audit, C++23 migration, warnings, and daemon structure
