### PR TITLE
style: add clang-format baseline for active files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+BreakBeforeBraces: Attach
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: true
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+Standard: Latest

--- a/vtcn-daemon/include/vtcn/config/phase0_runtime.hpp
+++ b/vtcn-daemon/include/vtcn/config/phase0_runtime.hpp
@@ -14,8 +14,6 @@ struct Phase0AppInfo {
 
 Phase0AppInfo phase0_app_info();
 
-int run_phase0_cli(std::ostream& out,
-                   std::ostream& err,
-                   const std::vector<std::string_view>& args);
+int run_phase0_cli(std::ostream &out, std::ostream &err, const std::vector<std::string_view> &args);
 
-}  // namespace vtcn::config
+} // namespace vtcn::config

--- a/vtcn-daemon/src/main.cpp
+++ b/vtcn-daemon/src/main.cpp
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <vector>
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     std::vector<std::string_view> args;
     args.reserve(static_cast<std::size_t>(argc));
 

--- a/vtcn-daemon/src/phase0_runtime.cpp
+++ b/vtcn-daemon/src/phase0_runtime.cpp
@@ -8,13 +8,13 @@ constexpr std::string_view kDaemonName = "vtcn-daemon";
 constexpr std::string_view kRuntimeMode = "virtual-development";
 constexpr std::string_view kProtocolTrack = "telemetry-v1-planning";
 
-void write_help(std::ostream& out) {
+void write_help(std::ostream &out) {
     out << "vtcn-daemon Phase 0 placeholder\n";
     out << "mode: " << kRuntimeMode << '\n';
     out << "usage: vtcn-daemon [--help|--version]\n";
 }
 
-}  // namespace
+} // namespace
 
 namespace vtcn::config {
 
@@ -22,9 +22,8 @@ Phase0AppInfo phase0_app_info() {
     return {kDaemonName, kRuntimeMode, kProtocolTrack};
 }
 
-int run_phase0_cli(std::ostream& out,
-                   std::ostream& err,
-                   const std::vector<std::string_view>& args) {
+int run_phase0_cli(std::ostream &out, std::ostream &err,
+                   const std::vector<std::string_view> &args) {
     if (args.size() <= 1 || args[1] == "--help") {
         write_help(out);
         return 0;
@@ -40,4 +39,4 @@ int run_phase0_cli(std::ostream& out,
     return 1;
 }
 
-}  // namespace vtcn::config
+} // namespace vtcn::config

--- a/vtcn-daemon/tests/integration/daemon_startup_smoke.cpp
+++ b/vtcn-daemon/tests/integration/daemon_startup_smoke.cpp
@@ -18,10 +18,7 @@ int main() {
     std::ostringstream err;
 
     const auto exit_code =
-        vtcn::config::run_phase0_cli(
-            out,
-            err,
-            std::vector<std::string_view>{"vtcn-daemon"});
+        vtcn::config::run_phase0_cli(out, err, std::vector<std::string_view>{"vtcn-daemon"});
 
     if (exit_code != 0) {
         return 1;

--- a/vtcn-daemon/tests/unit/phase0_runtime_test.cpp
+++ b/vtcn-daemon/tests/unit/phase0_runtime_test.cpp
@@ -20,11 +20,8 @@ TEST(Phase0RuntimeTest, HelpTextAdvertisesVirtualMode) {
     std::ostringstream out;
     std::ostringstream err;
 
-    const auto exit_code =
-        vtcn::config::run_phase0_cli(
-            out,
-            err,
-            std::vector<std::string_view>{"vtcn-daemon", "--help"});
+    const auto exit_code = vtcn::config::run_phase0_cli(
+        out, err, std::vector<std::string_view>{"vtcn-daemon", "--help"});
 
     EXPECT_EQ(exit_code, 0);
     EXPECT_TRUE(err.str().empty());
@@ -35,15 +32,12 @@ TEST(Phase0RuntimeTest, UnknownArgumentFailsClearly) {
     std::ostringstream out;
     std::ostringstream err;
 
-    const auto exit_code =
-        vtcn::config::run_phase0_cli(
-            out,
-            err,
-            std::vector<std::string_view>{"vtcn-daemon", "--unknown"});
+    const auto exit_code = vtcn::config::run_phase0_cli(
+        out, err, std::vector<std::string_view>{"vtcn-daemon", "--unknown"});
 
     EXPECT_NE(exit_code, 0);
     EXPECT_TRUE(out.str().empty());
     EXPECT_NE(err.str().find("--unknown"), std::string::npos);
 }
 
-}  // namespace
+} // namespace


### PR DESCRIPTION
## What changed
- added a conservative root .clang-format
- applied formatting only to the active tcn-daemon header, source, and test files
- left inactive and archived areas untouched

## Why
- issue #5 is about establishing a formatter baseline before the implementation-heavy weekend work
- doing this now reduces future style churn and keeps later diffs focused on behavior

## How to test
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- cmake --build build
- ctest --test-dir build --output-on-failure
- clang-format --version

## Result
- local configure passed
- local build passed
- local tests passed

Closes #5
