### PR TITLE
Integrate crank demo CLI summary

### DIFF
--- a/vtcn-daemon/include/vtcn/runtime/CrankDemoRuntime.hpp
+++ b/vtcn-daemon/include/vtcn/runtime/CrankDemoRuntime.hpp
@@ -15,6 +15,7 @@ struct CrankDemoAppInfo final {
 };
 
 [[nodiscard]] CrankDemoAppInfo crank_demo_app_info() noexcept;
+[[nodiscard]] crank::RuntimeSummary crank_demo_runtime_summary();
 
 [[nodiscard]] int run_crank_demo_cli(std::ostream &out, std::ostream &err,
                                      const std::vector<std::string_view> &args);

--- a/vtcn-daemon/src/crank_demo_runtime.cpp
+++ b/vtcn-daemon/src/crank_demo_runtime.cpp
@@ -1,5 +1,11 @@
 #include "vtcn/runtime/CrankDemoRuntime.hpp"
 
+#include "vtcn/crank/GapDetector.hpp"
+#include "vtcn/crank/RpmEstimator.hpp"
+#include "vtcn/crank/SimulatedCrankPulseSource.hpp"
+
+#include <cstddef>
+#include <cstdint>
 #include <ostream>
 
 namespace {
@@ -7,11 +13,46 @@ namespace {
 constexpr std::string_view kDaemonName = "vtcn-daemon";
 constexpr std::string_view kRuntimeMode = "host-side-validation";
 constexpr std::string_view kProtocolTrack = "telemetry-v1-planning";
+constexpr std::uint32_t kDemoTargetRpm = 600U;
+constexpr std::size_t kDemoRevolutionCount = 2U;
+
+[[nodiscard]] auto make_demo_config() -> vtcn::crank::CrankSignalConfig {
+    return vtcn::crank::CrankSignalConfig{
+        .target_rpm = vtcn::crank::Rpm{kDemoTargetRpm},
+        .revolution_count = vtcn::crank::Revolutions{kDemoRevolutionCount},
+        .start_time = vtcn::crank::Timestamp{0},
+    };
+}
 
 void write_help(std::ostream &out) {
-    out << "vtcn-daemon crank demo placeholder\n";
+    out << "vtcn-daemon crank demo\n";
     out << "mode: " << kRuntimeMode << '\n';
-    out << "usage: vtcn-daemon [--help|--version]\n";
+    out << "purpose: host-side Phase 0 validation of the 36-1 crank pipeline\n";
+    out << "usage: vtcn-daemon [--help|--version|--demo]\n";
+    out << "  --demo    run deterministic source, gap detection, and RPM estimation\n";
+}
+
+void write_runtime_summary(std::ostream &out, const vtcn::crank::RuntimeSummary &summary) {
+    out << "vtcn-daemon crank demo\n";
+    out << "mode: " << kRuntimeMode << '\n';
+    out << "validation: host-side Phase 0 deterministic 36-1 pipeline\n";
+    out << "target-rpm: " << summary.target_rpm.value << '\n';
+    out << "pulses-generated: " << summary.pulses_generated << '\n';
+
+    if (summary.gap_result.has_value()) {
+        out << "gap-index: " << summary.gap_result->gap_index << '\n';
+        out << "gap-interval-us: " << summary.gap_result->gap_interval.count() << '\n';
+    } else {
+        out << "gap-detection: unavailable\n";
+    }
+
+    if (summary.rpm_estimate.has_value()) {
+        out << "estimated-rpm: " << summary.rpm_estimate->estimated_rpm.value << '\n';
+        out << "nominal-tooth-interval-us: "
+            << summary.rpm_estimate->nominal_tooth_interval.count() << '\n';
+    } else {
+        out << "estimated-rpm: unavailable\n";
+    }
 }
 
 } // namespace
@@ -22,16 +63,45 @@ CrankDemoAppInfo crank_demo_app_info() noexcept {
     return {kDaemonName, kRuntimeMode, kProtocolTrack};
 }
 
+crank::RuntimeSummary crank_demo_runtime_summary() {
+    const auto profile = crank::default_crank_wheel_profile();
+    const auto config = make_demo_config();
+
+    const crank::SimulatedCrankPulseSource source{profile};
+    const auto pulses = source.generate(config);
+
+    const crank::GapDetector detector{};
+    const auto gap_result = detector.detect(pulses);
+
+    const crank::RpmEstimator estimator{};
+    const auto rpm_estimate =
+        gap_result.has_value() ? estimator.estimate(pulses, *gap_result) : std::nullopt;
+
+    return crank::RuntimeSummary{
+        .profile = profile,
+        .target_rpm = config.target_rpm,
+        .revolution_count = config.revolution_count,
+        .pulses_generated = pulses.size(),
+        .gap_result = gap_result,
+        .rpm_estimate = rpm_estimate,
+    };
+}
+
 int run_crank_demo_cli(std::ostream &out, std::ostream &err,
                        const std::vector<std::string_view> &args) {
-    if (args.size() <= 1 || args[1] == "--help") {
+    if (args.size() > 1 && args[1] == "--help") {
         write_help(out);
         return 0;
     }
 
-    if (args[1] == "--version") {
+    if (args.size() > 1 && args[1] == "--version") {
         const auto app_info = crank_demo_app_info();
         out << app_info.daemon_name << " crank-demo " << app_info.runtime_mode << '\n';
+        return 0;
+    }
+
+    if (args.size() <= 1 || args[1] == "--demo") {
+        write_runtime_summary(out, crank_demo_runtime_summary());
         return 0;
     }
 

--- a/vtcn-daemon/tests/integration/crank_demo_smoke.cpp
+++ b/vtcn-daemon/tests/integration/crank_demo_smoke.cpp
@@ -14,6 +14,23 @@ int main() {
         return 1;
     }
 
+    const auto summary = vtcn::runtime::crank_demo_runtime_summary();
+    if (!summary.gap_result.has_value()) {
+        return 1;
+    }
+
+    if (!summary.rpm_estimate.has_value()) {
+        return 1;
+    }
+
+    if (summary.target_rpm.value != 600U) {
+        return 1;
+    }
+
+    if (summary.rpm_estimate->estimated_rpm.value != 600U) {
+        return 1;
+    }
+
     std::ostringstream out;
     std::ostringstream err;
 
@@ -33,6 +50,18 @@ int main() {
     }
 
     if (out.str().find("host-side-validation") == std::string::npos) {
+        return 1;
+    }
+
+    if (out.str().find("target-rpm: 600") == std::string::npos) {
+        return 1;
+    }
+
+    if (out.str().find("estimated-rpm: 600") == std::string::npos) {
+        return 1;
+    }
+
+    if (out.str().find("gap-index: 35") == std::string::npos) {
         return 1;
     }
 

--- a/vtcn-daemon/tests/unit/crank_demo_runtime_test.cpp
+++ b/vtcn-daemon/tests/unit/crank_demo_runtime_test.cpp
@@ -16,7 +16,25 @@ TEST(CrankDemoRuntimeTest, AppInfoMatchesHostSideValidationMode) {
     EXPECT_EQ(app_info.protocol_track, "telemetry-v1-planning");
 }
 
-TEST(CrankDemoRuntimeTest, HelpTextAdvertisesHostSideValidation) {
+TEST(CrankDemoRuntimeTest, RuntimeSummaryMatchesDeterministicPipeline) {
+    const auto summary = vtcn::runtime::crank_demo_runtime_summary();
+
+    EXPECT_EQ(summary.profile.tooth_positions_per_revolution, 36U);
+    EXPECT_EQ(summary.profile.missing_tooth_count, 1U);
+    EXPECT_EQ(summary.target_rpm.value, 600U);
+    EXPECT_EQ(summary.revolution_count.value, 2U);
+    EXPECT_EQ(summary.pulses_generated, 70U);
+
+    ASSERT_TRUE(summary.gap_result.has_value());
+    EXPECT_EQ(summary.gap_result->gap_index, 35U);
+    EXPECT_EQ(summary.gap_result->gap_interval.count(), 5'554);
+
+    ASSERT_TRUE(summary.rpm_estimate.has_value());
+    EXPECT_EQ(summary.rpm_estimate->estimated_rpm.value, 600U);
+    EXPECT_EQ(summary.rpm_estimate->nominal_tooth_interval.count(), 2'777);
+}
+
+TEST(CrankDemoRuntimeTest, HelpTextDocumentsDemoArgumentAndValidationMode) {
     std::ostringstream out;
     std::ostringstream err;
 
@@ -25,7 +43,22 @@ TEST(CrankDemoRuntimeTest, HelpTextAdvertisesHostSideValidation) {
 
     EXPECT_EQ(exit_code, 0);
     EXPECT_TRUE(err.str().empty());
-    EXPECT_NE(out.str().find("host-side-validation"), std::string::npos);
+    EXPECT_NE(out.str().find("host-side Phase 0 validation"), std::string::npos);
+    EXPECT_NE(out.str().find("--demo"), std::string::npos);
+}
+
+TEST(CrankDemoRuntimeTest, DefaultInvocationRunsDeterministicDemo) {
+    std::ostringstream out;
+    std::ostringstream err;
+
+    const auto exit_code =
+        vtcn::runtime::run_crank_demo_cli(out, err, std::vector<std::string_view>{"vtcn-daemon"});
+
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_TRUE(err.str().empty());
+    EXPECT_NE(out.str().find("target-rpm: 600"), std::string::npos);
+    EXPECT_NE(out.str().find("estimated-rpm: 600"), std::string::npos);
+    EXPECT_NE(out.str().find("gap-index: 35"), std::string::npos);
 }
 
 TEST(CrankDemoRuntimeTest, UnknownArgumentFailsClearly) {


### PR DESCRIPTION
## Summary
- integrate the existing simulated crank source, gap detector, and RPM estimator into the runtime CLI
- add a deterministic runtime summary for the Phase 0 crank demo
- replace placeholder help/output text with honest host-side validation output
- extend runtime tests and smoke coverage for the new CLI contract

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure

## Follow-up
- presentation-oriented CLI upgrades tracked in #33

Closes #10